### PR TITLE
Stop removing sources files to get them added again

### DIFF
--- a/apt/repositories.sls
+++ b/apt/repositories.sls
@@ -96,7 +96,13 @@
     {% endif %}
     - onchanges_in:
       - module: apt.refresh_db
-
+  file.managed:
+    - name: {{ sources_list_dir }}/{{ r_file }}
+    - replace: false
+    - require_in:
+      - file: {{ sources_list_dir }}
+      # require_in the directory clean state
+      # This way, we don't remove all the files, just to add them again.
   {%- endfor %}
 {% endfor %}
 


### PR DESCRIPTION
I am annoyed that we clean the directory, even when there is nothing to clean.

This `require_in` will avoid removing files that don't need removing.