### PR TITLE
Add support Debian 11 and 12

### DIFF
--- a/apt/map.jinja
+++ b/apt/map.jinja
@@ -1,5 +1,7 @@
 {% set distribution = salt['grains.get']('lsb_distrib_codename') %}
 {% set arch = salt['grains.get']('osarch').split(' ') %}
+{% set debian_comp = ['main', 'contrib', 'non-free', 'non-free-firmware'] if salt['grains.get']('osmajorrelease') >= 12  else ['main', 'contrib', 'non-free'] %}
+
 {% set apt = salt['grains.filter_by']({
     'Debian': {
         'pkgs': ['unattended-upgrades'],
@@ -26,19 +28,22 @@
                 'distro': distribution,
                 'url': 'http://deb.debian.org/debian/',
                 'arch': arch,
-                'comps': ['main'],
+                'comps': debian_comp,
+                'opts': 'signed-by=/etc/apt/keyrings/salt-archive-keyring.pgp'
             },
             'security-stable': {
-                'distro': distribution ~ '/updates',
+                'distro': distribution ~ '-security',
                 'url': 'http://security.debian.org/',
                 'arch': arch,
-                'comps': ['main'],
+                'comps': debian_comp,
+                'opts': 'signed-by=/etc/apt/keyrings/salt-archive-keyring.pgp'
             },
             'default-updates': {
                 'distro': distribution ~ '-updates',
                 'url': 'http://deb.debian.org/debian/',
                 'arch': arch,
-                'comps': ['main'],
+                'comps': debian_comp,
+                'opts': 'signed-by=/etc/apt/keyrings/salt-archive-keyring.pgp'
             },
         },
     },
@@ -87,4 +92,5 @@
     'Mint': {
         'keyring_package': 'linuxmint-keyring'
     },
+
 }, grain='oscodename', merge=salt['pillar.get']('apt:lookup'), default='Debian')) %}

--- a/apt/repositories.sls
+++ b/apt/repositories.sls
@@ -96,7 +96,13 @@
     {% endif %}
     - onchanges_in:
       - module: apt.refresh_db
-
+  file.managed:
+    - name: {{ sources_list_dir }}/{{ r_file }}
+    - replace: false
+    - require_in:
+      - file: {{ sources_list_dir }}
+      # require_in the directory clean state
+      # This way, we don't remove all the files, just to add them again.
   {%- endfor %}
 {% endfor %}
 

--- a/test/integration/repositories/controls/repositories_spec.rb
+++ b/test/integration/repositories/controls/repositories_spec.rb
@@ -25,18 +25,6 @@ control 'Apt repositories' do
     its('mode') { should cmp '0755' }
   end
 
-  describe file('/etc/apt/sources.list.d/multimedia-stable-binary.list') do
-    it { should exist }
-    it { should be_owned_by 'root' }
-    it { should be_grouped_into 'root' }
-    its('mode') { should cmp '0644' }
-    its(:content) do
-      should match(
-        %r{deb \[arch=amd64\] http://www.deb-multimedia.org stable main}
-      )
-    end
-  end
-
   describe file('/etc/apt/sources.list.d/heroku-binary.list') do
     it { should exist }
     it { should be_owned_by 'root' }

--- a/test/salt/pillar/repositories.sls
+++ b/test/salt/pillar/repositories.sls
@@ -6,14 +6,6 @@ apt:
   clean_sources_list_d: true
 
   repositories:
-    ## relies on apt-key and this is deprecated
-    # multimedia-stable:
-    #   distro: stable
-    #   url: http://www.deb-multimedia.org
-    #   arch: [amd64]
-    #   comps: [main]
-    #   keyid: 5C808C2B65558117
-    #   keyserver: keyserver.ubuntu.com
     heroku:
       distro: ./
       url: https://cli-assets.heroku.com/apt

--- a/test/salt/pillar/repositories.sls
+++ b/test/salt/pillar/repositories.sls
@@ -6,13 +6,14 @@ apt:
   clean_sources_list_d: true
 
   repositories:
-    multimedia-stable:
-      distro: stable
-      url: http://www.deb-multimedia.org
-      arch: [amd64]
-      comps: [main]
-      keyid: 5C808C2B65558117
-      keyserver: keyserver.ubuntu.com
+    ## relies on apt-key and this is deprecated
+    # multimedia-stable:
+    #   distro: stable
+    #   url: http://www.deb-multimedia.org
+    #   arch: [amd64]
+    #   comps: [main]
+    #   keyid: 5C808C2B65558117
+    #   keyserver: keyserver.ubuntu.com
     heroku:
       distro: ./
       url: https://cli-assets.heroku.com/apt


### PR DESCRIPTION
- adds support for Debian 11 and Debian 12
- removes support for Debian 10
- Removes deb-multimedia.org test because it doesn't have an easy way set the gpg key

The tests `kitchen test repositories-debian-1[12]-master-py3` succeeded.