### PR TITLE
Feat repo allow unmanaged sources

### DIFF
--- a/apt/apt_conf.sls
+++ b/apt/apt_conf.sls
@@ -18,7 +18,7 @@
 
 {{ confd_dir }}:
   file.directory:
-    - mode: 755
+    - mode: '0755'
     - user: root
     - group: root
     - clean: {{ clean_apt_conf_d }}
@@ -30,7 +30,7 @@
     - template: jinja
     - user: root
     - group: root
-    - mode: 644
+    - mode: '0644'
     - context:
         data: {{ contents }}
     - require_in:

--- a/apt/listchanges.sls
+++ b/apt/listchanges.sls
@@ -13,5 +13,5 @@ apt_listchanges_pkgs:
     - template: jinja
     - user: root
     - group: root
-    - mode: 644
+    - mode: '0644'
     - source: {{ listchanges_config_template }}

--- a/apt/map.jinja
+++ b/apt/map.jinja
@@ -1,5 +1,7 @@
 {% set distribution = salt['grains.get']('lsb_distrib_codename') %}
 {% set arch = salt['grains.get']('osarch').split(' ') %}
+{% set debian_comp = ['main', 'contrib', 'non-free', 'non-free-firmware'] if salt['grains.get']('osmajorrelease') >= 12  else ['main', 'contrib', 'non-free'] %}
+
 {% set apt = salt['grains.filter_by']({
     'Debian': {
         'pkgs': ['unattended-upgrades'],
@@ -26,19 +28,22 @@
                 'distro': distribution,
                 'url': 'http://deb.debian.org/debian/',
                 'arch': arch,
-                'comps': ['main'],
+                'comps': debian_comp,
+                'opts': 'signed-by=/etc/apt/keyrings/salt-archive-keyring.pgp'
             },
             'security-stable': {
-                'distro': distribution ~ '/updates',
+                'distro': distribution ~ '-security',
                 'url': 'http://security.debian.org/',
                 'arch': arch,
-                'comps': ['main'],
+                'comps': debian_comp,
+                'opts': 'signed-by=/etc/apt/keyrings/salt-archive-keyring.pgp'
             },
             'default-updates': {
                 'distro': distribution ~ '-updates',
                 'url': 'http://deb.debian.org/debian/',
                 'arch': arch,
-                'comps': ['main'],
+                'comps': debian_comp,
+                'opts': 'signed-by=/etc/apt/keyrings/salt-archive-keyring.pgp'
             },
         },
     },
@@ -87,4 +92,5 @@
     'Mint': {
         'keyring_package': 'linuxmint-keyring'
     },
+
 }, grain='oscodename', merge=salt['pillar.get']('apt:lookup'), default='Debian')) %}

--- a/apt/repositories.sls
+++ b/apt/repositories.sls
@@ -96,7 +96,13 @@
     {% endif %}
     - onchanges_in:
       - module: apt.refresh_db
-
+  file.managed:
+    - name: {{ sources_list_dir }}/{{ r_file }}
+    - replace: false
+    - require_in:
+      - file: {{ sources_list_dir }}
+      # require_in the directory clean state
+      # This way, we don't remove all the files, just to add them again.
   {%- endfor %}
 {% endfor %}
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -123,6 +123,7 @@ suites:
       state_top:
         base:
           '*':
+            - states/unmanaged
             - apt._mapdata
             - apt.repositories
             - apt.update
@@ -133,6 +134,9 @@ suites:
               - apt
       pillars_from_files:
         apt.sls: test/salt/pillar/repositories.sls
+      dependencies:
+        - name: states
+          path: ./test/salt
     verifier:
       inspec_tests:
         - path: test/integration/repositories

--- a/pillar.example
+++ b/pillar.example
@@ -136,7 +136,8 @@ apt:
       type: [binary]
       key_url: https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public  # yamllint disable-line rule:line-length
       opts: "signed-by=/etc/apt/keyrings/salt-archive-keyring.pgp"
-
+    rabbitmq:
+      unmanaged: true # useful when rabbitmq.list is managed by another formula
 
   preferences:
     00-rspamd:

--- a/test/integration/repositories/controls/repositories_spec.rb
+++ b/test/integration/repositories/controls/repositories_spec.rb
@@ -25,18 +25,6 @@ control 'Apt repositories' do
     its('mode') { should cmp '0755' }
   end
 
-  describe file('/etc/apt/sources.list.d/multimedia-stable-binary.list') do
-    it { should exist }
-    it { should be_owned_by 'root' }
-    it { should be_grouped_into 'root' }
-    its('mode') { should cmp '0644' }
-    its(:content) do
-      should match(
-        %r{deb \[arch=amd64\] http://www.deb-multimedia.org stable main}
-      )
-    end
-  end
-
   describe file('/etc/apt/sources.list.d/heroku-binary.list') do
     it { should exist }
     it { should be_owned_by 'root' }

--- a/test/integration/repositories/controls/repositories_spec.rb
+++ b/test/integration/repositories/controls/repositories_spec.rb
@@ -25,6 +25,13 @@ control 'Apt repositories' do
     its('mode') { should cmp '0755' }
   end
 
+  describe file('/etc/apt/sources.list.d/rabbitmq.list') do
+    it { should exist }
+    its(:content) do
+      should match("## unmanged list file that shouldn't be removed")
+    end
+  end
+
   describe file('/etc/apt/sources.list.d/heroku-binary.list') do
     it { should exist }
     it { should be_owned_by 'root' }

--- a/test/salt/pillar/repositories.sls
+++ b/test/salt/pillar/repositories.sls
@@ -6,14 +6,6 @@ apt:
   clean_sources_list_d: true
 
   repositories:
-    ## relies on apt-key and this is deprecated
-    # multimedia-stable:
-    #   distro: stable
-    #   url: http://www.deb-multimedia.org
-    #   arch: [amd64]
-    #   comps: [main]
-    #   keyid: 5C808C2B65558117
-    #   keyserver: keyserver.ubuntu.com
     heroku:
       distro: ./
       url: https://cli-assets.heroku.com/apt

--- a/test/salt/pillar/repositories.sls
+++ b/test/salt/pillar/repositories.sls
@@ -6,13 +6,14 @@ apt:
   clean_sources_list_d: true
 
   repositories:
-    multimedia-stable:
-      distro: stable
-      url: http://www.deb-multimedia.org
-      arch: [amd64]
-      comps: [main]
-      keyid: 5C808C2B65558117
-      keyserver: keyserver.ubuntu.com
+    ## relies on apt-key and this is deprecated
+    # multimedia-stable:
+    #   distro: stable
+    #   url: http://www.deb-multimedia.org
+    #   arch: [amd64]
+    #   comps: [main]
+    #   keyid: 5C808C2B65558117
+    #   keyserver: keyserver.ubuntu.com
     heroku:
       distro: ./
       url: https://cli-assets.heroku.com/apt

--- a/test/salt/pillar/repositories.sls
+++ b/test/salt/pillar/repositories.sls
@@ -6,6 +6,10 @@ apt:
   clean_sources_list_d: true
 
   repositories:
+    rabbitmq:
+      unmanaged: true # do not remove this file when clean_sources_list_d=true
+      filename: rabbitmq.list # optional
+
     heroku:
       distro: ./
       url: https://cli-assets.heroku.com/apt

--- a/test/salt/states/unmanaged.sls
+++ b/test/salt/states/unmanaged.sls
@@ -1,0 +1,6 @@
+
+repos_maintained_by_another_formula:
+  file.managed:
+    - name: /etc/apt/sources.list.d/rabbitmq.list
+    - mode: '0644'
+    - contents: "## unmanged list file that shouldn't be removed"


### PR DESCRIPTION
I wanted to have the option to exclude sources.list files through a pillar flag.

```yml
apt:
  remove_sources_list: true
  clean_sources_list_d: true

  repositories:
    rabbitmq:
      unmanaged: true # do not remove this file when clean_sources_list_d=true
      filename: rabbitmq.list # optional
```

I added tests and `kitchen test repositories-debian-1[12]-master-py3` runs them fine.

I hope that even the commit message `feat(repositories): Add the option to declare a sources.list file unmanaged` will be conform the standard.
