### PR TITLE
feat(repositories): support for an unmanaged sources.list file

### DIFF
--- a/apt/apt_conf.sls
+++ b/apt/apt_conf.sls
@@ -18,7 +18,7 @@
 
 {{ confd_dir }}:
   file.directory:
-    - mode: 755
+    - mode: '0755'
     - user: root
     - group: root
     - clean: {{ clean_apt_conf_d }}
@@ -30,7 +30,7 @@
     - template: jinja
     - user: root
     - group: root
-    - mode: 644
+    - mode: '0644'
     - context:
         data: {{ contents }}
     - require_in:

--- a/apt/listchanges.sls
+++ b/apt/listchanges.sls
@@ -13,5 +13,5 @@ apt_listchanges_pkgs:
     - template: jinja
     - user: root
     - group: root
-    - mode: 644
+    - mode: '0644'
     - source: {{ listchanges_config_template }}

--- a/apt/map.jinja
+++ b/apt/map.jinja
@@ -1,5 +1,7 @@
 {% set distribution = salt['grains.get']('lsb_distrib_codename') %}
 {% set arch = salt['grains.get']('osarch').split(' ') %}
+{% set debian_comp = ['main', 'contrib', 'non-free', 'non-free-firmware'] if salt['grains.get']('osmajorrelease') >= 12  else ['main', 'contrib', 'non-free'] %}
+
 {% set apt = salt['grains.filter_by']({
     'Debian': {
         'pkgs': ['unattended-upgrades'],
@@ -26,19 +28,22 @@
                 'distro': distribution,
                 'url': 'http://deb.debian.org/debian/',
                 'arch': arch,
-                'comps': ['main'],
+                'comps': debian_comp,
+                'opts': 'signed-by=/etc/apt/keyrings/salt-archive-keyring.pgp'
             },
             'security-stable': {
-                'distro': distribution ~ '/updates',
+                'distro': distribution ~ '-security',
                 'url': 'http://security.debian.org/',
                 'arch': arch,
-                'comps': ['main'],
+                'comps': debian_comp,
+                'opts': 'signed-by=/etc/apt/keyrings/salt-archive-keyring.pgp'
             },
             'default-updates': {
                 'distro': distribution ~ '-updates',
                 'url': 'http://deb.debian.org/debian/',
                 'arch': arch,
-                'comps': ['main'],
+                'comps': debian_comp,
+                'opts': 'signed-by=/etc/apt/keyrings/salt-archive-keyring.pgp'
             },
         },
     },
@@ -87,4 +92,5 @@
     'Mint': {
         'keyring_package': 'linuxmint-keyring'
     },
+
 }, grain='oscodename', merge=salt['pillar.get']('apt:lookup'), default='Debian')) %}

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -123,6 +123,7 @@ suites:
       state_top:
         base:
           '*':
+            - states/unmanaged
             - apt._mapdata
             - apt.repositories
             - apt.update
@@ -133,6 +134,9 @@ suites:
               - apt
       pillars_from_files:
         apt.sls: test/salt/pillar/repositories.sls
+      dependencies:
+        - name: states
+          path: ./test/salt
     verifier:
       inspec_tests:
         - path: test/integration/repositories

--- a/pillar.example
+++ b/pillar.example
@@ -136,7 +136,8 @@ apt:
       type: [binary]
       key_url: https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public  # yamllint disable-line rule:line-length
       opts: "signed-by=/etc/apt/keyrings/salt-archive-keyring.pgp"
-
+    rabbitmq:
+      unmanaged: true # useful when rabbitmq.list is managed by another formula
 
   preferences:
     00-rspamd:

--- a/test/integration/repositories/controls/repositories_spec.rb
+++ b/test/integration/repositories/controls/repositories_spec.rb
@@ -25,15 +25,10 @@ control 'Apt repositories' do
     its('mode') { should cmp '0755' }
   end
 
-  describe file('/etc/apt/sources.list.d/multimedia-stable-binary.list') do
+  describe file('/etc/apt/sources.list.d/unmanaged.list') do
     it { should exist }
-    it { should be_owned_by 'root' }
-    it { should be_grouped_into 'root' }
-    its('mode') { should cmp '0644' }
     its(:content) do
-      should match(
-        %r{deb \[arch=amd64\] http://www.deb-multimedia.org stable main}
-      )
+      should match("## unmanged list file that shouldn't be removed")
     end
   end
 

--- a/test/salt/pillar/repositories.sls
+++ b/test/salt/pillar/repositories.sls
@@ -6,13 +6,10 @@ apt:
   clean_sources_list_d: true
 
   repositories:
-    multimedia-stable:
-      distro: stable
-      url: http://www.deb-multimedia.org
-      arch: [amd64]
-      comps: [main]
-      keyid: 5C808C2B65558117
-      keyserver: keyserver.ubuntu.com
+    unmanaged:
+      unmanaged: true # do not remove this file when clean_sources_list_d=true
+      filename: unmanaged.list # optional
+
     heroku:
       distro: ./
       url: https://cli-assets.heroku.com/apt

--- a/test/salt/states/unmanaged.sls
+++ b/test/salt/states/unmanaged.sls
@@ -1,0 +1,6 @@
+
+repos_maintained_by_another_formula:
+  file.managed:
+    - name: /etc/apt/sources.list.d/unmanaged.list
+    - mode: '0644'
+    - contents: "## unmanged list file that shouldn't be removed"


### PR DESCRIPTION
### PR progress checklist (to be filled in by reviewers)

- [ ] Changes to documentation are appropriate (or tick if not required)
- [ ] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?

Add a feature. In order to test said feature some fixes related to the Debian 11 and Debian 12 tests are done.

#### Primary type

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [x] `[feat]`     A new feature
- [ ] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [ ] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type

- [ ] `[docs]`     Documentation changes
- [x] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?

No. Technically compatibility with Debian 10 might be broken, but this is considered no longer supported.

### Related issues and/or pull requests


### Describe the changes you're proposing

- When setting `apt:clean_sources_list_d=true`  files that are not required to be removed are not removed
- A feature is added so that adding `apt:repositories:repo:unmanaged=true` allows you to specifically exclude a sources.list file from getting removed (or managed at all). This is handy in case another formula is managing this file.

### Pillar / config required to test the proposed changes



```yml
apt:
  clean_sources_list_d: true
  respositories:
    rabbitmq:
      unmanaged: true # useful when rabbitmq.list is managed by another formula
      filename: rabbitmq.list # this is optional, will use <repo-name>.list by default, instead of "<repo-name>-<type>.list"
```

### Documentation checklist

- [ ] Updated the `README` (e.g. `Available states`).
- [x] Updated `pillar.example`.

### Testing checklist

- [x] Included in Kitchen (i.e. under `state_top`).
- [x] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [x] Updated the relevant test pillar.

### Additional context

Added a Salt state to the tests to verify it isn't removed.

```yml
repos_maintained_by_another_formula:
  file.managed:
    - name: /etc/apt/sources.list.d/unmanaged.list
    - mode: '0644'
    - contents: "## unmanged list file that shouldn't be removed"

```



